### PR TITLE
Fix: Handle missing Hume access token gracefully in Page component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,15 @@ export default async function Page() {
   const accessToken = await getHumeAccessToken();
 
   if (!accessToken) {
-    throw new Error();
+    // Instead of throwing an error, return a component that displays an error message.
+    return (
+      <div className={"grow flex flex-col items-center justify-center p-4 text-center"}>
+        <h1 className="text-xl font-semibold mb-2">Application Error</h1>
+        <p className="mb-1">Could not retrieve the necessary access token to start the application.</p>
+        <p>This might be due to missing or incorrect API key configuration.</p>
+        <p>Please ensure server environment variables are set up correctly and try again.</p>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Instead of throwing a generic error when the Hume access token cannot be retrieved (e.g., due to missing API keys in the environment), display an informative error message on the page.

This prevents the build from crashing during prerendering and provides better user feedback if the application cannot start due to this issue.